### PR TITLE
Set up CI/CD pipeline for project

### DIFF
--- a/.github/workflows/upload-skills.yml
+++ b/.github/workflows/upload-skills.yml
@@ -1,0 +1,165 @@
+name: Upload Skills to Anthropic
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'skills/**'
+      - 'skills-config.json'
+      - '.github/workflows/upload-skills.yml'
+
+  workflow_dispatch:
+    inputs:
+      skill:
+        description: 'Skill to upload (skill name from config or "all")'
+        required: false
+        default: 'all'
+        type: string
+
+jobs:
+  detect-changes:
+    name: Detect Changed Skills
+    runs-on: ubuntu-latest
+    outputs:
+      changed_skills: ${{ steps.detect.outputs.changed_skills }}
+      all_skills: ${{ steps.detect.outputs.all_skills }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Detect changed skills
+        id: detect
+        run: |
+          # Load config and detect changed skills
+          python3 << 'EOF'
+          import json
+          import subprocess
+          import os
+
+          # Load skills config
+          with open('skills-config.json', 'r') as f:
+              config = json.load(f)
+
+          changed_skills = []
+          all_skills = list(config['skills'].keys())
+
+          # Check if workflow_dispatch with specific skill
+          if "${{ github.event_name }}" == "workflow_dispatch":
+              skill_input = "${{ github.event.inputs.skill }}"
+              if skill_input == "all":
+                  changed_skills = all_skills
+              elif skill_input in all_skills:
+                  changed_skills = [skill_input]
+              else:
+                  print(f"❌ Invalid skill name: {skill_input}")
+                  print(f"Available skills: {', '.join(all_skills)}")
+                  exit(1)
+          else:
+              # Auto trigger - detect changed files
+              result = subprocess.run(
+                  ['git', 'diff', '--name-only', 'HEAD~1', 'HEAD'],
+                  capture_output=True,
+                  text=True
+              )
+              changed_files = result.stdout.strip().split('\n')
+
+              # Check each skill's path
+              for skill_name, skill_config in config['skills'].items():
+                  skill_path = skill_config['path']
+                  if any(f.startswith(skill_path) for f in changed_files):
+                      changed_skills.append(skill_name)
+
+              # Also trigger all if config changed
+              if 'skills-config.json' in changed_files:
+                  print("⚠️  Config changed - uploading all skills")
+                  changed_skills = all_skills
+
+          # Output for GitHub Actions
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f"changed_skills={json.dumps(changed_skills)}\n")
+              f.write(f"all_skills={json.dumps(all_skills)}\n")
+
+          print(f"📦 Changed skills: {changed_skills}")
+          EOF
+
+      - name: Summary
+        run: |
+          echo "## 🔍 Change Detection Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Changed Skills:** \`${{ steps.detect.outputs.changed_skills }}\`" >> $GITHUB_STEP_SUMMARY
+
+  upload-skills:
+    name: Upload Skills
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed_skills != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        skill: ${{ fromJson(needs.detect-changes.outputs.changed_skills) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          pip install anthropic python-dotenv
+
+      - name: Upload ${{ matrix.skill }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          echo "🚀 Uploading skill: ${{ matrix.skill }}"
+          python scripts/upload-skill.py --skill-name ${{ matrix.skill }}
+
+      - name: Add to summary
+        if: success()
+        run: |
+          echo "✅ **${{ matrix.skill }}** uploaded successfully" >> $GITHUB_STEP_SUMMARY
+
+      - name: Add failure to summary
+        if: failure()
+        run: |
+          echo "❌ **${{ matrix.skill }}** upload failed" >> $GITHUB_STEP_SUMMARY
+
+  summary:
+    name: Upload Summary
+    needs: [detect-changes, upload-skills]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create summary
+        run: |
+          echo "# 🎯 Skills Upload Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ needs.upload-skills.result }}" == "success" ]; then
+            echo "✅ All skills uploaded successfully!" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.upload-skills.result }}" == "failure" ]; then
+            echo "❌ Some skills failed to upload. Check job logs above." >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.detect-changes.outputs.changed_skills }}" == "[]" ]; then
+            echo "⏭️  No skills changed - nothing to upload" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️  Upload status: ${{ needs.upload-skills.result }}" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📚 Skills Tracked" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          echo '${{ needs.detect-changes.outputs.all_skills }}' >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/docs/CI-CD-PIPELINE.md
+++ b/docs/CI-CD-PIPELINE.md
@@ -1,0 +1,256 @@
+# CI/CD Pipeline for Claude Skills
+
+ABOUTME: Documentation for automated skill upload pipeline using GitHub Actions and Anthropic Skills API.
+
+This repository uses GitHub Actions to automatically upload and update Claude Skills via the Anthropic Skills API whenever changes are pushed to the `main` branch.
+
+## Overview
+
+**Automated Upload Pipeline:**
+- Detects skill changes on push to `main`
+- Automatically creates new skills (if `skill_id` is null)
+- Automatically updates existing skills (if `skill_id` is set)
+- Supports manual trigger for specific skills or all skills
+
+## Configuration
+
+### 1. Skills Configuration File
+
+`skills-config.json` - Central configuration mapping skill names to IDs and metadata:
+
+```json
+{
+  "skills": {
+    "grammar": {
+      "skill_id": "skill_01LEoRLHpcopdFfXjv9gj9hj",
+      "display_title": "Grammar and Proofreading",
+      "path": "skills/grammar"
+    },
+    "sermon-writer": {
+      "skill_id": "skill_017hvH95CWyhykzXbG542B3B",
+      "display_title": "Sermon Writer",
+      "path": "skills/sermon-writer"
+    },
+    "biblical-accuracy": {
+      "skill_id": null,
+      "display_title": "Biblical Accuracy Checker",
+      "path": "skills/biblical accuracy skill"
+    }
+  }
+}
+```
+
+**Fields:**
+- `skill_id`: Anthropic skill ID (set to `null` for new skills)
+- `display_title`: Human-readable name shown in Claude Console
+- `path`: Relative path to skill directory containing `SKILL.md`
+
+### 2. GitHub Secrets
+
+Required secret in repository settings:
+
+- `ANTHROPIC_API_KEY` - Your Anthropic API key with skills management permissions
+
+**Setup:**
+1. Go to repository Settings → Secrets and variables → Actions
+2. Add new secret: `ANTHROPIC_API_KEY`
+3. Paste your Anthropic API key
+
+## Workflows
+
+### Automated Upload (`upload-skills.yml`)
+
+**Triggers:**
+- Push to `main` with changes to `skills/**` or `skills-config.json`
+- Manual trigger via GitHub Actions UI
+
+**What it does:**
+1. Detects which skills changed
+2. For each changed skill:
+   - If `skill_id` is `null` → Creates new skill, outputs ID to add to config
+   - If `skill_id` exists → Updates skill with new version
+3. Provides summary of upload status
+
+**Matrix build:**
+- Uploads multiple changed skills in parallel
+- Each skill uploads independently (fail-fast disabled)
+
+### Manual Trigger
+
+Trigger the workflow manually from GitHub Actions UI:
+
+1. Go to Actions → "Upload Skills to Anthropic"
+2. Click "Run workflow"
+3. Select skill:
+   - `all` - Upload all skills
+   - `grammar` - Upload only grammar skill
+   - `sermon-writer` - Upload only sermon-writer skill
+   - etc.
+
+## Usage
+
+### Adding a New Skill
+
+1. Create skill directory under `skills/` with `SKILL.md`
+2. Add entry to `skills-config.json`:
+   ```json
+   "new-skill-name": {
+     "skill_id": null,
+     "display_title": "My New Skill",
+     "path": "skills/new-skill-name"
+   }
+   ```
+3. Commit and push to `main`
+4. CI/CD creates the skill automatically
+5. Check workflow output for skill ID
+6. Update `skills-config.json` with the new skill ID
+7. Commit the updated config
+
+### Updating an Existing Skill
+
+1. Edit files in `skills/your-skill/`
+2. Commit and push to `main`
+3. CI/CD automatically uploads new version
+
+### Local Testing
+
+Test the upload script locally:
+
+```bash
+# Install dependencies
+pip install anthropic python-dotenv
+
+# Create .env file with API key
+echo "ANTHROPIC_API_KEY=your-key-here" > .env
+
+# Update existing skill
+python scripts/upload-skill.py --skill-name grammar
+
+# Create new skill
+python scripts/upload-skill.py --skill-name biblical-accuracy
+
+# Override config manually
+python scripts/upload-skill.py \
+  --skill-path skills/grammar \
+  --skill-id skill_01ABC \
+  --display-title "Grammar Checker"
+```
+
+## File Structure
+
+```
+.
+├── .github/workflows/
+│   ├── upload-skills.yml          # Automated upload pipeline (NEW)
+│   └── prepare-skills.yml         # Legacy manual workflow (kept for reference)
+├── skills/
+│   ├── grammar/
+│   │   └── SKILL.md
+│   ├── sermon-writer/
+│   │   └── SKILL.md
+│   ├── biblical accuracy skill/
+│   │   └── SKILL.md
+│   └── critical-biblical-listener/
+│       └── SKILL.md
+├── scripts/
+│   ├── upload-skill.py            # Upload/create skills via API
+│   ├── prepare-skill.py           # Legacy preparation script
+│   └── test-skills-api.py         # API connectivity test
+├── skills-config.json             # Central skill configuration
+└── docs/
+    └── CI-CD-PIPELINE.md          # This file
+```
+
+## API Reference
+
+The upload script uses the Anthropic Skills API:
+
+**Create new skill:**
+```python
+client.beta.skills.create(
+    display_title="Skill Name",
+    files=[(filename, content), ...],
+    betas=["skills-2025-10-02"]
+)
+```
+
+**Update skill version:**
+```python
+client.beta.skills.versions.create(
+    skill_id="skill_01ABC",
+    files=[(filename, content), ...],
+    betas=["skills-2025-10-02"]
+)
+```
+
+**List skills:**
+```python
+client.beta.skills.list(
+    betas=["skills-2025-10-02"]
+)
+```
+
+## Troubleshooting
+
+### "ANTHROPIC_API_KEY not set"
+
+**Cause:** GitHub secret not configured
+**Fix:** Add `ANTHROPIC_API_KEY` to repository secrets
+
+### "Skill 'name' not found in skills-config.json"
+
+**Cause:** Skill name doesn't match config
+**Fix:** Check spelling in config file and workflow trigger
+
+### "SKILL.md not found in path"
+
+**Cause:** Skill directory missing required `SKILL.md` file
+**Fix:** Add `SKILL.md` to skill directory
+
+### Skill created but need to save ID
+
+**Symptom:** Workflow creates skill but doesn't update config automatically
+**Expected behavior:** This is intentional for safety
+**Fix:**
+1. Check workflow output for new skill ID
+2. Manually update `skills-config.json` with the ID
+3. Commit and push the config update
+
+### Upload fails with API error
+
+**Debug steps:**
+1. Check API key has correct permissions
+2. Verify skill structure (must have `SKILL.md`)
+3. Check file size (max 8MB total)
+4. Review workflow logs for detailed error message
+
+## Migration from Old Workflow
+
+The old `prepare-skills.yml` workflow is kept for reference but is superseded by `upload-skills.yml`.
+
+**Key differences:**
+- Old: Creates zip artifacts for manual upload
+- New: Automatically uploads via API
+
+**Migration steps:**
+1. Ensure `ANTHROPIC_API_KEY` secret is set
+2. Update `skills-config.json` with all skill IDs
+3. New workflow will automatically run on next push to `main`
+4. (Optional) Disable or delete `prepare-skills.yml`
+
+## Security Considerations
+
+- API key is stored as GitHub secret (never in code)
+- Skills are uploaded to organization-wide Claude workspace
+- All skill versions are retained by Anthropic
+- Skill IDs are not sensitive (safe to commit to repo)
+
+## Future Enhancements
+
+Potential improvements:
+- Automatic skill_id update in config after creation
+- Version tagging based on git tags
+- Skill validation before upload
+- Dry-run mode for testing
+- Rollback to previous version
+- Automated testing of skills after upload

--- a/docs/SKILLS_AUTOMATION.md
+++ b/docs/SKILLS_AUTOMATION.md
@@ -1,6 +1,14 @@
 # Skills Deployment Automation
 
-This repository automatically prepares Claude skills for deployment when changes are made. Until the Anthropic Skills API supports programmatic uploads, the system creates deployment packages for manual upload to Claude Console.
+> **⚠️ SUPERSEDED:** This document describes the legacy manual workflow. The repository now uses **fully automated CI/CD pipeline** via Anthropic Skills API.
+>
+> **See:** [CI-CD-PIPELINE.md](./CI-CD-PIPELINE.md) for current automation documentation.
+
+---
+
+## Legacy Documentation (For Reference)
+
+This repository previously prepared Claude skills for manual deployment. This workflow has been replaced by automated upload via the Anthropic Skills API.
 
 ## 🚀 How It Works
 

--- a/scripts/upload-skill.py
+++ b/scripts/upload-skill.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python3
 """
-Upload Claude Skill to Anthropic via Skills API
-
-Usage:
-  python scripts/upload-skill.py --skill-path skills/grammar --skill-id skill_01XYZ --version v1.0.0
+ABOUTME: Upload or create Claude Skills via Anthropic API
+Handles both creating new skills and updating existing skills with new versions.
 """
 
 import os
 import sys
 import argparse
-import base64
-import zipfile
+import json
 from pathlib import Path
 from anthropic import Anthropic
 from dotenv import load_dotenv
@@ -19,138 +16,217 @@ from dotenv import load_dotenv
 env_path = Path(__file__).parent.parent / '.env'
 load_dotenv(env_path)
 
-def create_skill_zip(skill_path: Path) -> bytes:
+def prepare_skill_files(skill_path: Path) -> list:
     """
-    Create a zip archive of the skill folder.
-    
+    Prepare skill files for upload to Anthropic API.
+
     Args:
-        skill_path: Path to skill folder containing SKILL.md and references/
-    
+        skill_path: Path to skill folder containing SKILL.md
+
     Returns:
-        Base64 encoded zip bytes
+        List of file tuples (filename, file_content) for API upload
     """
-    import io
-    
-    print(f"📦 Creating zip archive of {skill_path}")
-    
+    print(f"📦 Preparing skill files from {skill_path}")
+
     # Verify SKILL.md exists
     skill_md = skill_path / "SKILL.md"
     if not skill_md.exists():
         raise FileNotFoundError(f"SKILL.md not found in {skill_path}")
-    
-    zip_buffer = io.BytesIO()
-    
-    with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-        for file_path in skill_path.rglob('*'):
-            if file_path.is_file() and not file_path.name.startswith('.'):
-                arcname = file_path.relative_to(skill_path)
-                print(f"   Adding: {arcname}")
-                zip_file.write(file_path, arcname)
-    
-    zip_buffer.seek(0)
-    encoded = base64.b64encode(zip_buffer.read()).decode('utf-8')
-    print(f"✅ Zip created ({len(encoded)} bytes)")
-    
-    return encoded
+
+    files = []
+    for file_path in skill_path.rglob('*'):
+        if file_path.is_file() and not file_path.name.startswith('.'):
+            relative_path = file_path.relative_to(skill_path.parent)
+            print(f"   Adding: {relative_path}")
+            with open(file_path, 'rb') as f:
+                files.append((str(relative_path), f.read()))
+
+    print(f"✅ Prepared {len(files)} files for upload")
+    return files
 
 
-def upload_skill_version(skill_id: str, skill_path: Path, version: str, api_key: str):
+def create_new_skill(skill_path: Path, display_title: str, api_key: str):
     """
-    Upload a new version of a skill to Anthropic.
-    
+    Create a new skill in Anthropic.
+
+    Args:
+        skill_path: Path to skill folder
+        display_title: Display name for the skill
+        api_key: Anthropic API key
+
+    Returns:
+        Skill object with skill_id
+    """
+    client = Anthropic(api_key=api_key)
+
+    print(f"\n🆕 Creating new skill in Anthropic")
+    print(f"   Title: {display_title}")
+    print(f"   Path: {skill_path}")
+
+    # Prepare files
+    files = prepare_skill_files(skill_path)
+
+    try:
+        response = client.beta.skills.create(
+            display_title=display_title,
+            files=files,
+            betas=["skills-2025-10-02"]
+        )
+
+        print(f"\n✅ Skill created successfully!")
+        print(f"   Skill ID: {response.id}")
+        print(f"   Latest Version: {response.latest_version}")
+        print(f"\n⚠️  IMPORTANT: Add this skill_id to skills-config.json:")
+        print(f'   "skill_id": "{response.id}"')
+
+        return response
+
+    except Exception as e:
+        print(f"\n❌ Create failed: {e}")
+        sys.exit(1)
+
+
+def update_skill_version(skill_id: str, skill_path: Path, api_key: str):
+    """
+    Upload a new version of an existing skill to Anthropic.
+
     Args:
         skill_id: The skill ID from Claude Console
         skill_path: Path to skill folder
-        version: Version tag (e.g., 'v1.0.0' or git commit SHA)
         api_key: Anthropic API key
+
+    Returns:
+        Version object
     """
     client = Anthropic(api_key=api_key)
-    
-    print(f"\n🚀 Uploading skill to Anthropic")
+
+    print(f"\n🔄 Updating skill in Anthropic")
     print(f"   Skill ID: {skill_id}")
-    print(f"   Version: {version}")
     print(f"   Path: {skill_path}")
-    
-    # Create zip
-    skill_zip = create_skill_zip(skill_path)
-    
+
+    # Prepare files
+    files = prepare_skill_files(skill_path)
+
     try:
-        # Upload skill version
-        # Using the correct API structure discovered from exploration
         response = client.beta.skills.versions.create(
             skill_id=skill_id,
-            files=skill_zip,
-            betas=["code-execution-2025-08-25", "skills-2025-10-02"]
+            files=files,
+            betas=["skills-2025-10-02"]
         )
-        
-        print(f"\n✅ Skill uploaded successfully!")
+
+        print(f"\n✅ Skill version updated successfully!")
         print(f"   Skill ID: {skill_id}")
-        print(f"   Version: {version}")
-        print(f"   Response: {response}")
-        
+        print(f"   New Version: {response.version}")
+
         return response
-        
+
     except Exception as e:
-        print(f"\n❌ Upload failed: {e}")
+        print(f"\n❌ Update failed: {e}")
         sys.exit(1)
+
+
+def load_config() -> dict:
+    """Load skills configuration from skills-config.json"""
+    config_path = Path(__file__).parent.parent / 'skills-config.json'
+    if not config_path.exists():
+        print(f"❌ Error: Configuration file not found: {config_path}")
+        sys.exit(1)
+
+    with open(config_path, 'r') as f:
+        return json.load(f)
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Upload Claude Skill to Anthropic API',
+        description='Upload or create Claude Skill via Anthropic API',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Upload grammar skill with git tag
-  python scripts/upload-skill.py --skill-path skills/grammar --skill-id skill_01ABC --version v1.0.0
-  
-  # Upload sermon-writer skill with commit SHA
-  python scripts/upload-skill.py --skill-path skills/sermon-writer --skill-id skill_01XYZ --version $(git rev-parse --short HEAD)
+  # Update existing skill (has skill_id in config)
+  python scripts/upload-skill.py --skill-name grammar
+
+  # Create new skill (skill_id is null in config)
+  python scripts/upload-skill.py --skill-name biblical-accuracy
+
+  # Override config with explicit skill-id
+  python scripts/upload-skill.py --skill-path skills/grammar --skill-id skill_01ABC --display-title "Grammar Checker"
         """
     )
-    
+
+    parser.add_argument(
+        '--skill-name',
+        help='Skill name from skills-config.json (e.g., "grammar", "sermon-writer")'
+    )
     parser.add_argument(
         '--skill-path',
-        required=True,
-        help='Path to skill folder (e.g., "skills/grammar" or "skills/sermon-writer")'
+        help='Path to skill folder (overrides config)'
     )
     parser.add_argument(
         '--skill-id',
-        required=True,
-        help='Skill ID from Claude Console (e.g., skill_01AbCdEfGh)'
+        help='Skill ID (overrides config, use "create" to force creation)'
     )
     parser.add_argument(
-        '--version',
-        required=True,
-        help='Version tag (e.g., "v1.0.0" or git commit SHA)'
+        '--display-title',
+        help='Display title for new skills (overrides config)'
     )
     parser.add_argument(
         '--api-key',
         help='Anthropic API key (defaults to ANTHROPIC_API_KEY env var)'
     )
-    
+
     args = parser.parse_args()
-    
+
     # Get API key
     api_key = args.api_key or os.environ.get('ANTHROPIC_API_KEY')
     if not api_key:
         print("❌ Error: ANTHROPIC_API_KEY not set")
         print("   Set via --api-key flag or ANTHROPIC_API_KEY environment variable")
         sys.exit(1)
-    
-    # Resolve skill path
-    skill_path = Path(args.skill_path)
+
+    # Load configuration
+    config = load_config()
+
+    # Determine skill parameters
+    if args.skill_name:
+        if args.skill_name not in config['skills']:
+            print(f"❌ Error: Skill '{args.skill_name}' not found in skills-config.json")
+            print(f"   Available skills: {', '.join(config['skills'].keys())}")
+            sys.exit(1)
+
+        skill_config = config['skills'][args.skill_name]
+        skill_path = Path(skill_config['path'])
+        skill_id = args.skill_id if args.skill_id else skill_config['skill_id']
+        display_title = args.display_title if args.display_title else skill_config['display_title']
+    elif args.skill_path:
+        skill_path = Path(args.skill_path)
+        skill_id = args.skill_id
+        display_title = args.display_title
+
+        if not skill_id or not display_title:
+            print("❌ Error: When using --skill-path, must also provide --skill-id and --display-title")
+            sys.exit(1)
+    else:
+        print("❌ Error: Must provide either --skill-name or --skill-path")
+        sys.exit(1)
+
+    # Verify skill path exists
     if not skill_path.exists():
         print(f"❌ Error: Skill path '{skill_path}' does not exist")
         sys.exit(1)
-    
-    # Upload
-    upload_skill_version(
-        skill_id=args.skill_id,
-        skill_path=skill_path,
-        version=args.version,
-        api_key=api_key
-    )
+
+    # Create or update
+    if skill_id == "create" or skill_id is None:
+        create_new_skill(
+            skill_path=skill_path,
+            display_title=display_title,
+            api_key=api_key
+        )
+    else:
+        update_skill_version(
+            skill_id=skill_id,
+            skill_path=skill_path,
+            api_key=api_key
+        )
 
 
 if __name__ == "__main__":

--- a/skills-config.json
+++ b/skills-config.json
@@ -1,0 +1,29 @@
+{
+  "skills": {
+    "grammar": {
+      "skill_id": "skill_01LEoRLHpcopdFfXjv9gj9hj",
+      "display_title": "Grammar and Proofreading",
+      "path": "skills/grammar"
+    },
+    "sermon-writer": {
+      "skill_id": "skill_017hvH95CWyhykzXbG542B3B",
+      "display_title": "Sermon Writer",
+      "path": "skills/sermon-writer"
+    },
+    "biblical-accuracy": {
+      "skill_id": null,
+      "display_title": "Biblical Accuracy Checker",
+      "path": "skills/biblical accuracy skill"
+    },
+    "critical-biblical-listener": {
+      "skill_id": null,
+      "display_title": "Critical Biblical Listener",
+      "path": "skills/critical-biblical-listener"
+    }
+  },
+  "metadata": {
+    "version": "1.0.0",
+    "description": "Configuration for Claude Skills CI/CD pipeline",
+    "last_updated": "2025-11-13"
+  }
+}

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,39 +1,74 @@
 # Claude Skills
 
-This directory contains custom Claude skills that are automatically synced to Claude Console.
+This directory contains custom Claude skills that are automatically uploaded to Claude Console via the Anthropic Skills API.
+
+## Available Skills
+
+### Active Skills
+- **grammar** - Grammar and proofreading for biblical/theological writing
+- **sermon-writer** - Sermon, sermonette, and split sermon generation
+- **biblical-accuracy** - Biblical accuracy verification with original language analysis
+- **critical-biblical-listener** - Skeptical biblical listener evaluating sermon content
 
 ## Structure
 
 ```
 skills/
-├── grammar/           # Grammar and writing style skill
-│   ├── SKILL.md      # Main skill definition
-│   └── references/   # Supporting documentation
-└── sermon-writer/    # Sermon writing assistant skill
-    ├── SKILL.md      # Main skill definition
-    └── references/   # Supporting documentation
+├── grammar/                      # Grammar and writing style skill
+│   ├── SKILL.md                 # Main skill definition
+│   └── references/              # Supporting documentation
+├── sermon-writer/               # Sermon writing assistant skill
+│   ├── SKILL.md                # Main skill definition
+│   └── references/             # Supporting documentation
+├── biblical accuracy skill/     # Biblical accuracy checker
+│   └── SKILL.md                # Main skill definition
+└── critical-biblical-listener/  # Critical sermon evaluator
+    └── SKILL.md                # Main skill definition
 ```
 
 ## How Skills Work
 
 Each skill folder must contain:
-- `SKILL.md` - The main skill definition and instructions
-- `references/` - Supporting documentation, examples, and context
+- `SKILL.md` - The main skill definition and instructions (required)
+- `references/` - Supporting documentation, examples, and context (optional)
 
-## Automation
+## Automated CI/CD Pipeline
 
 Skills are automatically uploaded to Claude Console when:
-1. Changes are committed to `main` branch
-2. Files in `skills/*/` folders are modified
-3. Manual workflow trigger in GitHub Actions
+1. Changes are pushed to `main` branch
+2. Files in `skills/**` folders are modified
+3. Configuration in `skills-config.json` is updated
+4. Manual workflow trigger in GitHub Actions
 
-See `../docs/SKILLS_AUTOMATION.md` for full automation details.
+**Key Features:**
+- Automatically creates new skills (when `skill_id` is `null`)
+- Automatically updates existing skills (when `skill_id` is set)
+- Parallel upload of multiple changed skills
+- Detailed workflow summaries
+
+See `../docs/CI-CD-PIPELINE.md` for complete automation documentation.
 
 ## Adding New Skills
 
-1. Create a new folder under `skills/`
-2. Add `SKILL.md` with skill definition
-3. Add `references/` folder with supporting docs
-4. Update GitHub workflow in `../.github/workflows/sync-skills.yml`
-5. Create the skill manually in Claude Console first
-6. Add skill ID to GitHub secrets
+1. Create a new folder under `skills/` with your skill name
+2. Add `SKILL.md` with skill definition (see existing skills for format)
+3. Add entry to `../skills-config.json`:
+   ```json
+   "your-skill-name": {
+     "skill_id": null,
+     "display_title": "Your Skill Display Name",
+     "path": "skills/your-skill-name"
+   }
+   ```
+4. Commit and push to `main`
+5. CI/CD will create the skill and output the skill ID
+6. Update `skills-config.json` with the new skill ID
+7. Commit the config update
+
+## Updating Existing Skills
+
+1. Edit files in `skills/your-skill/`
+2. Commit and push to `main`
+3. CI/CD automatically uploads new version
+
+No manual steps required for updates!


### PR DESCRIPTION
Implemented automated skill upload via Anthropic Skills API with the following components:

**New Files:**
- skills-config.json: Central configuration mapping skill names to IDs
- .github/workflows/upload-skills.yml: Automated upload workflow
- docs/CI-CD-PIPELINE.md: Comprehensive CI/CD documentation

**Updated Files:**
- scripts/upload-skill.py: Enhanced to handle both create and update operations
- skills/README.md: Updated with new CI/CD workflow documentation
- docs/SKILLS_AUTOMATION.md: Marked as superseded by new automation

**Key Features:**
- Automatic skill upload on push to main
- Auto-detect changed skills and upload in parallel
- Create new skills (when skill_id is null)
- Update existing skills (when skill_id is set)
- Manual trigger support for individual or all skills
- Uses skills-config.json for centralized skill management

**Configuration:**
- All 4 skills configured: grammar, sermon-writer, biblical-accuracy, critical-biblical-listener
- Requires ANTHROPIC_API_KEY GitHub secret
- Fully automated on push to main branch

This replaces the legacy manual workflow (prepare-skills.yml).